### PR TITLE
Add GitHub Skills Activity - Fixes #6

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Wednesdays, 3:30 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚨 Urgent: Add Missing GitHub Skills Activity

This PR addresses the time-sensitive issue raised by 11th grade student Hewbie C. regarding the missing GitHub Skills activity that was announced by the principal.

### 📝 Changes Made

- **Added "GitHub Skills" activity** to the extracurricular activities list
- **Description**: Emphasizes practical coding and collaboration skills through GitHub, highlighting it's part of the GitHub Certifications program for college applications
- **Schedule**: Mondays and Wednesdays, 3:30 PM - 4:30 PM
- **Capacity**: 25 students (generous capacity given expected high demand)
- **Initial participants**: None (ready for registrations)

### ⏰ Timeline

This addresses the urgent timeline mentioned in the issue - registrations close by end of this week. Students have been eagerly waiting to sign up since the principal's announcement.

### ✅ Testing

- [x] Activity appears in activities list
- [x] Students can now find and register for GitHub Skills
- [x] No breaking changes to existing functionality
- [x] Maintains consistent data structure

### 🎯 Impact

- Resolves student frustration from not being able to find the announced activity
- Enables students to participate in the GitHub Certifications program
- Supports college application enhancement opportunities

Fixes #6

---

**Note**: This implementation follows the existing pattern in the codebase and maintains compatibility with the current frontend interface.